### PR TITLE
Select the latest tag by version code when version names tie

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ For the plugin to work, there needs to be at least one [semantic version](https:
 for example `1.2.3+45`. The plugin will parse the `versionName` from the `MAJOR.MINOR.PATCH`, and the
 `versionCode` from numeric `metadata` of the latest version tag.
 
+The latest tag is chosen by semantic version precedence. Because semver precedence ignores build
+metadata, tags that share a `MAJOR.MINOR.PATCH` (e.g. successive builds `1.2.3+45` and `1.2.3+46`)
+are ranked by their numeric build metadata, so the one with the highest `versionCode` wins.
+
 ## Non-release builds
 
 For non-release build types, if the version is inferred from a git tag, the calculated version code is

--- a/plugin/src/main/kotlin/com/eygraber/ReleaseTagVersionTask.kt
+++ b/plugin/src/main/kotlin/com/eygraber/ReleaseTagVersionTask.kt
@@ -233,7 +233,13 @@ abstract class ReleaseTagVersionTask : DefaultTask() {
           .lineSequence()
           .filter { it.startsWith(versionPrefix.get()) }
           .mapNotNull { it.removePrefix(versionPrefix.get()).toVersionOrNull() }
-          .maxOrNull()
+          // Semver precedence ignores build metadata, so tags that share a version name (e.g.
+          // successive builds 1.2.3+4 and 1.2.3+5) compare equal and maxOrNull would pick an
+          // arbitrary one. The build metadata holds the version code, so tie-break equal-precedence
+          // tags by it to select the highest version code.
+          .maxWithOrNull(
+            compareBy<Version> { it }.thenBy { it.buildMetadata?.toIntOrNull() ?: 0 },
+          )
 
       else -> null
     }

--- a/plugin/src/test/kotlin/com/eygraber/ReleaseTagVersionPluginTest.kt
+++ b/plugin/src/test/kotlin/com/eygraber/ReleaseTagVersionPluginTest.kt
@@ -262,6 +262,36 @@ class ReleaseTagVersionPluginTest {
   }
 
   @Test
+  fun `the highest version code wins when tags share a version name`() {
+    writeBuildFiles()
+
+    // Tagged out of order so the result can't come from git's listing order; semver precedence
+    // ties on the shared 1.2.3 name, leaving the build metadata as the only differentiator.
+    gitInit("1.2.3+4", "1.2.3+6", "1.2.3+5")
+
+    val result = runGradle("assembleRelease")
+
+    result.output shouldContain "Using versionCode 6 from LatestGitTag"
+    result.output shouldContain "Using versionName 1.2.3 from LatestGitTag"
+
+    ensureConfigurationCacheReuse("assembleRelease")
+  }
+
+  @Test
+  fun `a higher version name wins over a higher version code`() {
+    writeBuildFiles()
+
+    gitInit("1.2.3+9", "1.2.4+1")
+
+    val result = runGradle("assembleRelease")
+
+    result.output shouldContain "Using versionCode 1 from LatestGitTag"
+    result.output shouldContain "Using versionName 1.2.4 from LatestGitTag"
+
+    ensureConfigurationCacheReuse("assembleRelease")
+  }
+
+  @Test
   fun `git tag without version code is used`() {
     writeBuildFiles()
 


### PR DESCRIPTION
Semver precedence ignores build metadata, so release tags that share a MAJOR.MINOR.PATCH (e.g. successive builds 1.2.3+4 and 1.2.3+5) compared equal and the latest-tag selection could return an older build. The build metadata carries the versionCode, so the inferred code could stall for projects that ship multiple builds under one versionName. This tie-breaks equal-precedence tags by their numeric build metadata so the highest versionCode wins.