### PR TITLE
Support isolated projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ A Gradle plugin that uses the latest git semantic version tag to set the version
 
 2.  The plugin will automatically use the latest git semantic version tag to set the version code and version name.
 
+The plugin is compatible with the
+[configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html) and
+[isolated projects](https://docs.gradle.org/current/userguide/isolated_projects.html).
+
 ## Git Tag Format
 
 For the plugin to work, there needs to be at least one [semantic version](https://semver.org/) tag,

--- a/plugin/src/main/kotlin/com/eygraber/ReleaseTagVersionPlugin.kt
+++ b/plugin/src/main/kotlin/com/eygraber/ReleaseTagVersionPlugin.kt
@@ -129,13 +129,10 @@ class ReleaseTagVersionPlugin : Plugin<Project> {
       group = "Versioning"
       description = "Infers the version code and name from the latest git release tag and writes it to a file"
 
-      val gitDir = rootProject.file(".git/refs/tags")
-      if(gitDir.exists()) {
-        this.gitDir.set(gitDir)
-      }
-
-      val tagsDir = rootProject.file(".git/refs/tags")
-      if(tagsDir.exists()) {
+      // rootProject.file would be a cross-project access, which isolated projects forbids
+      val tagsDir = isolated.rootProject.projectDirectory.dir(".git/refs/tags")
+      if(tagsDir.asFile.exists()) {
+        this.gitDir.set(tagsDir)
         this.gitTagsDir.set(tagsDir)
       }
 

--- a/plugin/src/test/kotlin/com/eygraber/ReleaseTagVersionPluginTest.kt
+++ b/plugin/src/test/kotlin/com/eygraber/ReleaseTagVersionPluginTest.kt
@@ -23,6 +23,20 @@ class ReleaseTagVersionPluginTest {
   }
 
   @Test
+  fun `plugin works with isolated projects`() {
+    writeBuildFiles(isolatedProjects = true)
+
+    gitInit("1.2.3+4")
+
+    val result = runGradle("assembleRelease")
+
+    result.output shouldContain "Using versionCode 4 from LatestGitTag"
+    result.output shouldContain "Using versionName 1.2.3 from LatestGitTag"
+
+    ensureConfigurationCacheReuse("assembleRelease")
+  }
+
+  @Test
   fun `versionCodeIsInferred false doesn't set the version code`() {
     writeBuildFiles(
       """
@@ -753,6 +767,7 @@ class ReleaseTagVersionPluginTest {
   private fun writeBuildFiles(
     @Language("kotlin")
     buildGradleContent: String = "",
+    isolatedProjects: Boolean = false,
   ) {
     val androidSdkHome = System.getenv("ANDROID_HOME")
 
@@ -768,9 +783,19 @@ class ReleaseTagVersionPluginTest {
       set("org.gradle.parallel", "true")
       set("org.gradle.configuration-cache", "true")
       set("org.gradle.configuration-cache.parallel", "true")
+      if(isolatedProjects) {
+        set("org.gradle.unsafe.isolated-projects", "true")
+      }
       testProjectDir.newFile("gradle.properties").outputStream().use {
         store(it, null)
       }
+    }
+
+    // isolated projects violations only surface across project boundaries,
+    // so the app needs to live in a subproject instead of the root project
+    val appProjectInclude = when {
+      isolatedProjects -> """include(":androidApp")"""
+      else -> ""
     }
 
     testProjectDir.newFile("settings.gradle.kts").writeText(
@@ -793,10 +818,17 @@ class ReleaseTagVersionPluginTest {
       |}
       |
       |rootProject.name = "test-project"
+      |
+      |$appProjectInclude
       """.trimMargin(),
     )
 
-    testProjectDir.newFile("build.gradle.kts").writeText(
+    val appProjectDir = when {
+      isolatedProjects -> testProjectDir.newFolder("androidApp")
+      else -> testProjectDir.root
+    }
+
+    File(appProjectDir, "build.gradle.kts").writeText(
       $$"""
       |plugins {
       |  id("com.android.application")
@@ -828,8 +860,8 @@ class ReleaseTagVersionPluginTest {
       """.trimMargin(),
     )
 
-    testProjectDir.newFolder("src/main")
-    testProjectDir.newFile("src/main/AndroidManifest.xml").writeText(
+    val mainDir = File(appProjectDir, "src/main").apply { mkdirs() }
+    File(mainDir, "AndroidManifest.xml").writeText(
       """
       |<?xml version="1.0" encoding="utf-8"?>
       |<manifest xmlns:android="http://schemas.android.com/apk/res/android" />


### PR DESCRIPTION
Fixes the isolated projects violation reported when the plugin is applied to a subproject:

```
Plugin 'com.android.internal.application': Project ':androidApp' cannot access 'Project.file' functionality on another project ':'
```

## What changed

- `registerInferVersionTask` used `rootProject.file(".git/refs/tags")` to locate the git tags directory, which is a cross-project access when the plugin is applied to a non-root project. It now uses `isolated.rootProject.projectDirectory` (the `IsolatedProject` API, Gradle 8.8+), which is safe under isolated projects. The two identical `gitDir`/`tagsDir` lookups were also collapsed into one.
- Added a `plugin works with isolated projects` test that applies the plugin to an `:androidApp` subproject with `org.gradle.unsafe.isolated-projects=true`. The existing tests applied the plugin to the root project, so the cross-project access was never exercised. The test fails with the old code with the same error as above, and verifies configuration cache reuse with the fix.
- Added a compatibility note to the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)