### PR TITLE
Wire versionOverrideFile extension property into the infer version task

### DIFF
--- a/plugin/src/main/kotlin/com/eygraber/ReleaseTagVersionPlugin.kt
+++ b/plugin/src/main/kotlin/com/eygraber/ReleaseTagVersionPlugin.kt
@@ -136,10 +136,11 @@ class ReleaseTagVersionPlugin : Plugin<Project> {
         this.gitTagsDir.set(tagsDir)
       }
 
-      val versionOverrideFile = project.file(".version-override")
-      if(versionOverrideFile.exists()) {
-        this.versionOverrideFile.set(versionOverrideFile)
-      }
+      // a missing file is filtered out so the @Optional @InputFile is treated as absent
+      // instead of failing validation
+      this.versionOverrideFile.set(
+        extension.versionOverrideFile.filter { it.asFile.exists() },
+      )
 
       this.versionCodeIsInferred.set(extension.versionCodeIsInferred)
       this.versionNameIsInferred.set(extension.versionNameIsInferred)

--- a/plugin/src/test/kotlin/com/eygraber/ReleaseTagVersionPluginTest.kt
+++ b/plugin/src/test/kotlin/com/eygraber/ReleaseTagVersionPluginTest.kt
@@ -262,6 +262,28 @@ class ReleaseTagVersionPluginTest {
   }
 
   @Test
+  fun `a custom versionOverrideFile is used`() {
+    writeBuildFiles(
+      """
+      |releaseTagVersion {
+      |  versionOverrideFile.set(layout.projectDirectory.file("custom-version-override"))
+      |}
+      """.trimMargin(),
+    )
+
+    gitInit("1.0.0+1")
+    writeVersionOverrideFile("1.0.0+2")
+    testProjectDir.newFile("custom-version-override").writeText("1.2.3+5")
+
+    val result = runGradle("assembleRelease")
+
+    result.output shouldContain "Using versionCode 5 from OverridingFile"
+    result.output shouldContain "Using versionName 1.2.3 from OverridingFile"
+
+    ensureConfigurationCacheReuse("assembleRelease")
+  }
+
+  @Test
   fun `git tag is used`() {
     writeBuildFiles()
 


### PR DESCRIPTION
## Summary

The `releaseTagVersion.versionOverrideFile` extension property had a convention and README documentation, but the infer version task hardcoded `project.file(".version-override")` — so configuring a custom path had no effect.

- Wire the extension property into the task using `Provider.filter { it.asFile.exists() }`, which keeps the `@Optional @InputFile` absent when the file is missing (instead of failing input validation) and keeps the existence check lazy and tracked by the configuration cache.
- Add a test that configures a custom `versionOverrideFile` alongside a default `.version-override` with a different version, and verifies the custom file wins (it fails against the previous hardcoded behavior).

## Testing

- Full `ReleaseTagVersionPluginTest` suite passes (34 tests), including the existing configuration-cache invalidation test for the override file.
- Verified the new test fails with the fix reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)