### PR TITLE
Support resolving git tags when running in a linked worktree

### DIFF
--- a/plugin/src/main/kotlin/com/eygraber/ReleaseTagVersionPlugin.kt
+++ b/plugin/src/main/kotlin/com/eygraber/ReleaseTagVersionPlugin.kt
@@ -14,6 +14,7 @@ import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
+import java.io.File
 import java.util.Locale
 
 /**
@@ -130,8 +131,9 @@ class ReleaseTagVersionPlugin : Plugin<Project> {
       description = "Infers the version code and name from the latest git release tag and writes it to a file"
 
       // rootProject.file would be a cross-project access, which isolated projects forbids
-      val tagsDir = isolated.rootProject.projectDirectory.dir(".git/refs/tags")
-      if(tagsDir.asFile.exists()) {
+      val dotGit = isolated.rootProject.projectDirectory.file(".git").asFile
+      val tagsDir = dotGit.resolveGitCommonDir()?.resolve("refs/tags")
+      if(tagsDir != null && tagsDir.exists()) {
         this.gitDir.set(tagsDir)
         this.gitTagsDir.set(tagsDir)
       }
@@ -156,4 +158,32 @@ class ReleaseTagVersionPlugin : Plugin<Project> {
       this.versionNameFile.set(versionNameFile)
     }
   }
+}
+
+private fun File.resolveGitCommonDir(): File? = when {
+  isDirectory -> this
+
+  // in a linked worktree .git is a file containing "gitdir: <worktree git dir>",
+  // and that dir's commondir file points to the main repository's .git dir,
+  // which is where refs/tags lives (tags are shared across worktrees)
+  isFile -> {
+    val worktreeGitDir =
+      readText()
+        .substringAfter("gitdir:", missingDelimiterValue = "")
+        .trim()
+        .takeIf { it.isNotEmpty() }
+        ?.let { parentFile.resolve(it).normalize() }
+
+    val commonDir =
+      worktreeGitDir
+        ?.resolve("commondir")
+        ?.takeIf(File::isFile)
+        ?.readText()
+        ?.trim()
+        ?.let { worktreeGitDir.resolve(it).normalize() }
+
+    (commonDir ?: worktreeGitDir)?.takeIf(File::isDirectory)
+  }
+
+  else -> null
 }

--- a/plugin/src/test/kotlin/com/eygraber/ReleaseTagVersionPluginTest.kt
+++ b/plugin/src/test/kotlin/com/eygraber/ReleaseTagVersionPluginTest.kt
@@ -15,6 +15,9 @@ class ReleaseTagVersionPluginTest {
   @get:Rule
   val testProjectDir = TemporaryFolder()
 
+  @get:Rule
+  val mainRepoDir = TemporaryFolder()
+
   @Test
   fun `plugin applies successfully`() {
     writeBuildFiles()
@@ -295,6 +298,42 @@ class ReleaseTagVersionPluginTest {
     result.output shouldContain "Using versionName 1.2.3 from LatestGitTag"
 
     ensureConfigurationCacheReuse("assembleRelease")
+  }
+
+  @Test
+  fun `git tag is used when the project is a linked worktree`() {
+    gitInit("1.2.3+4", directory = mainRepoDir.root)
+    gitWorktreeAdd(mainRepo = mainRepoDir.root, worktree = testProjectDir.root)
+
+    writeBuildFiles()
+
+    val result = runGradle("assembleRelease")
+
+    result.output shouldContain "Using versionCode 4 from LatestGitTag"
+    result.output shouldContain "Using versionName 1.2.3 from LatestGitTag"
+
+    ensureConfigurationCacheReuse("assembleRelease")
+  }
+
+  @Test
+  fun `a new git tag in the main repository invalidates a worktree's task but not the configuration cache`() {
+    gitInit("1.2.3+4", directory = mainRepoDir.root)
+    gitWorktreeAdd(mainRepo = mainRepoDir.root, worktree = testProjectDir.root)
+
+    writeBuildFiles()
+
+    val result = runGradle("assembleRelease")
+
+    result.output shouldContain "Using versionCode 4 from LatestGitTag"
+    result.output shouldContain "Using versionName 1.2.3 from LatestGitTag"
+
+    gitTag("1.2.4+5", directory = mainRepoDir.root)
+
+    val nextResult = runGradle("assembleRelease")
+
+    nextResult.output shouldContain "Using versionCode 5 from LatestGitTag"
+    nextResult.output shouldContain "Using versionName 1.2.4 from LatestGitTag"
+    nextResult.output shouldContain "Reusing configuration cache."
   }
 
   @Test
@@ -730,9 +769,10 @@ class ReleaseTagVersionPluginTest {
 
   private fun gitInit(
     vararg tags: String,
+    directory: File = testProjectDir.root,
   ) {
     ProcessBuilder("git", "init")
-      .directory(testProjectDir.root)
+      .directory(directory)
       .start()
       .apply {
         if(waitFor() != 0) {
@@ -740,12 +780,15 @@ class ReleaseTagVersionPluginTest {
         }
       }
 
-    gitCommit("initial commit")
+    gitCommit("initial commit", directory = directory)
 
-    gitTag(*tags)
+    gitTag(*tags, directory = directory)
   }
 
-  private fun gitCommit(message: String) {
+  private fun gitCommit(
+    message: String,
+    directory: File = testProjectDir.root,
+  ) {
     ProcessBuilder(
       "git",
       "-c",
@@ -757,7 +800,7 @@ class ReleaseTagVersionPluginTest {
       "-m",
       message,
     )
-      .directory(testProjectDir.root)
+      .directory(directory)
       .start()
       .apply {
         if(waitFor() != 0) {
@@ -768,10 +811,11 @@ class ReleaseTagVersionPluginTest {
 
   private fun gitTag(
     vararg tags: String,
+    directory: File = testProjectDir.root,
   ) {
     tags.forEach { tag ->
       ProcessBuilder("git", "tag", tag)
-        .directory(testProjectDir.root)
+        .directory(directory)
         .start()
         .apply {
           if(waitFor() != 0) {
@@ -779,6 +823,20 @@ class ReleaseTagVersionPluginTest {
           }
         }
     }
+  }
+
+  private fun gitWorktreeAdd(
+    mainRepo: File,
+    worktree: File,
+  ) {
+    ProcessBuilder("git", "worktree", "add", worktree.absolutePath)
+      .directory(mainRepo)
+      .start()
+      .apply {
+        if(waitFor() != 0) {
+          error("Failed to create git worktree - ${errorReader().readText()}")
+        }
+      }
   }
 
   private fun writeVersionOverrideFile(version: String) {


### PR DESCRIPTION
## Problem

When a build runs in a linked git worktree, the plugin never finds any tags and silently falls back to the fallback version. The plugin assumed `.git` is a directory and looked for `.git/refs/tags`, but in a linked worktree `.git` is a file containing a `gitdir:` pointer to the worktree's private git dir.

## Fix

Resolve the git common dir instead of assuming the layout:

- If `.git` is a directory, use it as-is (unchanged behavior)
- If `.git` is a file, follow the `gitdir:` pointer to the worktree's git dir, then read its `commondir` file to reach the main repository's `.git` dir

Tags are shared across worktrees and live in the common dir, so `<commonDir>/refs/tags` is both the correct place to run `git tag -l` from and the correct `@InputDirectory` for up-to-date checks. Relative `gitdir:` and `commondir` values (what git writes by default) are resolved and normalized.

## Tests

- `git tag is used when the project is a linked worktree` — a tag in the main repo is picked up when Gradle runs in the worktree, with configuration cache reuse
- `a new git tag in the main repository invalidates a worktree's task but not the configuration cache`

The git helpers in the test are parameterized with a target directory so they can operate on a main repo separate from the project dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)