### PR TITLE
Support suffixing the version name

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ For non-release build types, if the version is inferred from a git tag, the calc
 incremented by one. This is done to ensure that a non-release build always has a higher version code than the
 corresponding release build.
 
+## Version name suffixes
+
+The `versionNameSuffix` that a variant's product flavors and build type declare in the Android DSL is
+applied to the inferred version name, in the order AGP would apply it - the flavors' suffixes in
+dimension order, then the build type's. A `1.2.3` tag builds a `1.2.3-DEBUG` debug APK when the debug
+build type sets `versionNameSuffix = "-DEBUG"`.
+
+`releaseTagVersion.versionNameSuffix` adds one more suffix after those, for identifying a build that
+isn't a release - a CI build of a pull request, for example:
+
+```bash
+./gradlew assembleDebug -PversionNameSuffix=-my-branch
+```
+
+That produces `1.2.3-DEBUG-my-branch`. The suffix is appended verbatim, so it is up to the caller to
+keep the result a valid semantic version if anything downstream parses it.
+
 ## Configuration
 
 The plugin can be configured using the `releaseTagVersion` extension in your `build.gradle.kts` file.
@@ -108,6 +125,12 @@ releaseTagVersion {
   // A prefix to use when searching for git tags.
   // Default: "" (empty string)
   versionPrefix.set("")
+
+  // A suffix to append to the version name, after the versionNameSuffix that the variant's
+  // product flavors and build type declare in the Android DSL.
+  // Can also be set with the versionNameSuffix Gradle property.
+  // Default: none
+  versionNameSuffix.set("-my-branch")
 
   // The build types that are considered "release" builds.
   // For these build types, the version code will be used as-is.

--- a/plugin/api/plugin.api
+++ b/plugin/api/plugin.api
@@ -6,6 +6,7 @@ public abstract interface class com/eygraber/ReleaseTagVersionExtension {
 	public abstract fun getVersionCodeOverride ()Lorg/gradle/api/provider/Property;
 	public abstract fun getVersionNameIsInferred ()Lorg/gradle/api/provider/Property;
 	public abstract fun getVersionNameOverride ()Lorg/gradle/api/provider/Property;
+	public abstract fun getVersionNameSuffix ()Lorg/gradle/api/provider/Property;
 	public abstract fun getVersionOverride ()Lorg/gradle/api/provider/Property;
 	public abstract fun getVersionOverrideFile ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getVersionPrefix ()Lorg/gradle/api/provider/Property;
@@ -32,6 +33,7 @@ public abstract class com/eygraber/ReleaseTagVersionTask : org/gradle/api/Defaul
 	public abstract fun getVersionNameFile ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getVersionNameIsInferred ()Lorg/gradle/api/provider/Property;
 	public abstract fun getVersionNameOverride ()Lorg/gradle/api/provider/Property;
+	public abstract fun getVersionNameSuffix ()Lorg/gradle/api/provider/Property;
 	public abstract fun getVersionOverride ()Lorg/gradle/api/provider/Property;
 	public abstract fun getVersionOverrideFile ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getVersionPrefix ()Lorg/gradle/api/provider/Property;

--- a/plugin/src/main/kotlin/com/eygraber/ReleaseTagVersionExtension.kt
+++ b/plugin/src/main/kotlin/com/eygraber/ReleaseTagVersionExtension.kt
@@ -72,6 +72,19 @@ interface ReleaseTagVersionExtension {
   val versionNameOverride: Property<String>
 
   /**
+   * A suffix that is appended to the version name.
+   *
+   * It is applied after the `versionNameSuffix` that the variant's product flavors and build type
+   * declare in the Android DSL, so a `1.2.3` debug build of a project whose debug build type sets a
+   * `-DEBUG` suffix becomes `1.2.3-DEBUG-my-branch` when this is set to `-my-branch`.
+   *
+   * The suffix is appended verbatim; nothing checks that the result is still a valid semantic version.
+   *
+   * Default: none
+   */
+  val versionNameSuffix: Property<String>
+
+  /**
    * The build types that are considered "release" builds.
    * For these build types, the version code will be used as-is.
    * For other build types (e.g., "debug"), the version code will be incremented by 1.

--- a/plugin/src/main/kotlin/com/eygraber/ReleaseTagVersionPlugin.kt
+++ b/plugin/src/main/kotlin/com/eygraber/ReleaseTagVersionPlugin.kt
@@ -1,6 +1,5 @@
 package com.eygraber
 
-import com.android.build.api.dsl.ApplicationDefaultConfig
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.ApplicationVariant
@@ -9,6 +8,7 @@ import com.android.build.gradle.AppPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.findByType
@@ -40,6 +40,7 @@ class ReleaseTagVersionPlugin : Plugin<Project> {
     versionOverride.convention(project.findProperty("versionOverride") as? String)
     versionCodeOverride.convention((project.findProperty("versionCodeOverride") as? String)?.toIntOrNull())
     versionNameOverride.convention(project.findProperty("versionNameOverride") as? String)
+    versionNameSuffix.convention(project.findProperty("versionNameSuffix") as? String)
     versionPrefix.convention("")
     releaseBuildTypes.convention(setOf("release"))
   }
@@ -47,13 +48,12 @@ class ReleaseTagVersionPlugin : Plugin<Project> {
   private fun Project.configureVariants(extension: ReleaseTagVersionExtension) {
     plugins.withType<AppPlugin> {
       val appExtension = extensions.findByType<ApplicationExtension>()
-      val defaultConfig = appExtension?.defaultConfig
 
       extensions.findByType<ApplicationAndroidComponentsExtension>()?.onVariants { variant ->
         processVariant(
           variant = variant,
           extension = extension,
-          defaultConfig = defaultConfig,
+          appExtension = appExtension,
         )
       }
     }
@@ -62,7 +62,7 @@ class ReleaseTagVersionPlugin : Plugin<Project> {
   private fun Project.processVariant(
     variant: ApplicationVariant,
     extension: ReleaseTagVersionExtension,
-    defaultConfig: ApplicationDefaultConfig?,
+    appExtension: ApplicationExtension?,
   ) {
     val versionCodeFile = objects.fileProperty().convention(
       layout.buildDirectory.file("generated/com/eygraber/release/tag/version/${variant.name}/code.txt"),
@@ -72,20 +72,32 @@ class ReleaseTagVersionPlugin : Plugin<Project> {
       layout.buildDirectory.file("generated/com/eygraber/release/tag/version/${variant.name}/name.txt"),
     )
 
+    // setting the version name on the variant output replaces whatever AGP composed from the DSL,
+    // including the versionNameSuffix declared by the variant's product flavors and build type, so
+    // the plugin has to re-apply it. The extension's own suffix goes after it, the way AGP applies
+    // the build type's suffix after the flavors'.
+    var dslVersionNameSuffix = dslVersionNameSuffix(appExtension, variant)
+
+    var defaultVersionCode = appExtension?.defaultConfig?.versionCode
+    var defaultVersionName = appExtension?.defaultConfig?.versionName
+
+    afterEvaluate {
+      dslVersionNameSuffix = dslVersionNameSuffix(appExtension, variant)
+      defaultVersionCode = appExtension?.defaultConfig?.versionCode
+      defaultVersionName = appExtension?.defaultConfig?.versionName
+    }
+
+    val versionNameSuffix =
+      provider { dslVersionNameSuffix }
+        .zip(extension.versionNameSuffix.orElse("")) { dslSuffix, suffix -> "$dslSuffix$suffix" }
+
     val inferVersionTask = registerInferVersionTask(
       variant = variant,
       extension = extension,
+      versionNameSuffix = versionNameSuffix,
       versionCodeFile = versionCodeFile,
       versionNameFile = versionNameFile,
     )
-
-    var defaultVersionCode = defaultConfig?.versionCode
-    var defaultVersionName = defaultConfig?.versionName
-
-    afterEvaluate {
-      defaultVersionCode = defaultConfig?.versionCode
-      defaultVersionName = defaultConfig?.versionName
-    }
 
     variant
       .outputs
@@ -103,6 +115,7 @@ class ReleaseTagVersionPlugin : Plugin<Project> {
           },
         )
 
+        // the inferred name already carries the suffixes, because the task writes them into the file
         output.versionName.set(
           extension.versionNameIsInferred.flatMap { isInferred ->
             when {
@@ -111,7 +124,9 @@ class ReleaseTagVersionPlugin : Plugin<Project> {
                   .flatMap(ReleaseTagVersionTask::versionNameFile)
                   .map { it.asFile.readText() }
 
-              else -> provider { defaultVersionName }
+              else ->
+                provider { defaultVersionName }
+                  .zip(versionNameSuffix) { versionName, suffix -> "$versionName$suffix" }
             }
           },
         )
@@ -121,6 +136,7 @@ class ReleaseTagVersionPlugin : Plugin<Project> {
   private fun Project.registerInferVersionTask(
     variant: Variant,
     extension: ReleaseTagVersionExtension,
+    versionNameSuffix: Provider<String>,
     versionCodeFile: RegularFileProperty,
     versionNameFile: RegularFileProperty,
   ): TaskProvider<ReleaseTagVersionTask> {
@@ -150,12 +166,34 @@ class ReleaseTagVersionPlugin : Plugin<Project> {
       this.versionOverride.set(extension.versionOverride)
       this.versionCodeOverride.set(extension.versionCodeOverride)
       this.versionNameOverride.set(extension.versionNameOverride)
+      this.versionNameSuffix.set(versionNameSuffix)
       this.releaseBuildTypes.set(extension.releaseBuildTypes)
       this.versionPrefix.set(extension.versionPrefix)
       this.fallbackVersionCode.set(extension.fallbackVersionCode)
       this.fallbackVersionName.set(extension.fallbackVersionName)
       this.versionCodeFile.set(versionCodeFile)
       this.versionNameFile.set(versionNameFile)
+    }
+  }
+}
+
+/**
+ * The `versionNameSuffix` AGP would have applied to [variant] - its product flavors' suffixes in
+ * dimension order, followed by its build type's.
+ */
+private fun dslVersionNameSuffix(
+  appExtension: ApplicationExtension?,
+  variant: Variant,
+): String = when(appExtension) {
+  null -> ""
+
+  else -> buildString {
+    variant.productFlavors.forEach { (_, flavorName) ->
+      append(appExtension.productFlavors.findByName(flavorName)?.versionNameSuffix.orEmpty())
+    }
+
+    variant.buildType?.let { buildTypeName ->
+      append(appExtension.buildTypes.findByName(buildTypeName)?.versionNameSuffix.orEmpty())
     }
   }
 }

--- a/plugin/src/main/kotlin/com/eygraber/ReleaseTagVersionTask.kt
+++ b/plugin/src/main/kotlin/com/eygraber/ReleaseTagVersionTask.kt
@@ -73,6 +73,10 @@ abstract class ReleaseTagVersionTask : DefaultTask() {
   abstract val versionNameOverride: Property<String>
 
   @get:Input
+  @get:Optional
+  abstract val versionNameSuffix: Property<String>
+
+  @get:Input
   abstract val releaseBuildTypes: SetProperty<String>
 
   @get:Input
@@ -190,10 +194,12 @@ abstract class ReleaseTagVersionTask : DefaultTask() {
           ?: fallbackInfo.nameAndSource()
           ?: error("Couldn't find a version name")
 
+      val finalVersionName = "$versionName${versionNameSuffix.orNull.orEmpty()}"
+
       versionNameFile.get().asFile.apply {
         parentFile.mkdirs()
         writeText(
-          versionName.also {
+          finalVersionName.also {
             logger.info("Using versionName $it from $source")
           },
         )

--- a/plugin/src/test/kotlin/com/eygraber/ReleaseTagVersionPluginTest.kt
+++ b/plugin/src/test/kotlin/com/eygraber/ReleaseTagVersionPluginTest.kt
@@ -198,6 +198,123 @@ class ReleaseTagVersionPluginTest {
   }
 
   @Test
+  fun `versionNameSuffix is appended to the version name`() {
+    writeBuildFiles(
+      """
+      |releaseTagVersion {
+      |  versionNameSuffix.set("-my-branch")
+      |}
+      """.trimMargin(),
+    )
+
+    gitInit("1.2.3+4")
+
+    val result = runGradle("assembleRelease")
+
+    result.output shouldContain "Using versionCode 4 from LatestGitTag"
+    result.output shouldContain "Using versionName 1.2.3-my-branch from LatestGitTag"
+
+    ensureConfigurationCacheReuse("assembleRelease")
+  }
+
+  @Test
+  fun `versionNameSuffix is appended to an overridden version name`() {
+    writeBuildFiles(
+      """
+      |releaseTagVersion {
+      |  versionNameOverride.set("5.4.3")
+      |  versionNameSuffix.set("-my-branch")
+      |}
+      """.trimMargin(),
+    )
+
+    gitInit("1.2.3+4")
+
+    val result = runGradle("assembleRelease")
+
+    result.output shouldContain "Using versionName 5.4.3-my-branch from OverridingProperty"
+
+    ensureConfigurationCacheReuse("assembleRelease")
+  }
+
+  @Test
+  fun `the build type's versionNameSuffix is applied`() {
+    writeBuildFiles(
+      """
+      |android {
+      |  buildTypes {
+      |    debug {
+      |      versionNameSuffix = "-DEBUG"
+      |    }
+      |  }
+      |}
+      """.trimMargin(),
+    )
+
+    gitInit("1.2.3+4")
+
+    val result = runGradle("assembleDebug")
+
+    result.output shouldContain "Using versionCode 5 from LatestGitTag"
+    result.output shouldContain "Using versionName 1.2.3-DEBUG from LatestGitTag"
+
+    ensureConfigurationCacheReuse("assembleDebug")
+  }
+
+  @Test
+  fun `a product flavor's versionNameSuffix is applied before the build type's`() {
+    writeBuildFiles(
+      """
+      |android {
+      |  flavorDimensions += "environment"
+      |
+      |  productFlavors {
+      |    create("dev") {
+      |      dimension = "environment"
+      |      versionNameSuffix = "-dev"
+      |    }
+      |  }
+      |
+      |  buildTypes {
+      |    debug {
+      |      versionNameSuffix = "-DEBUG"
+      |    }
+      |  }
+      |}
+      |
+      |releaseTagVersion {
+      |  versionNameSuffix.set("-my-branch")
+      |}
+      """.trimMargin(),
+    )
+
+    gitInit("1.2.3+4")
+
+    val result = runGradle("assembleDevDebug")
+
+    result.output shouldContain "Using versionName 1.2.3-dev-DEBUG-my-branch from LatestGitTag"
+
+    ensureConfigurationCacheReuse("assembleDevDebug")
+  }
+
+  @Test
+  fun `versionNameSuffix invalidates the task and configuration cache`() {
+    writeBuildFiles()
+
+    gitInit("1.2.3+4")
+
+    val result = runGradle("assembleRelease")
+
+    result.output shouldContain "Using versionName 1.2.3 from LatestGitTag"
+
+    val nextResult = runGradle("assembleRelease", "-PversionNameSuffix=-my-branch")
+
+    nextResult.output shouldContain "Using versionCode 4 from LatestGitTag"
+    nextResult.output shouldContain "Using versionName 1.2.3-my-branch from LatestGitTag"
+    nextResult.output shouldNotContain "Reusing configuration cache."
+  }
+
+  @Test
   fun `versionNameOverride overrides versionOverride`() {
     writeBuildFiles(
       """


### PR DESCRIPTION
Setting the version name on the variant output replaces the value AGP composed from the DSL, so a `versionNameSuffix` declared by a build type or product flavor never reached the APK. The plugin now re-applies it, in the order AGP would — the flavors' suffixes in dimension order, then the build type's.

On top of that, `releaseTagVersion.versionNameSuffix` (or `-PversionNameSuffix`) appends one more suffix, for identifying a build that isn't a release:

```bash
./gradlew assembleDebug -PversionNameSuffix=-my-branch
```

With a `-DEBUG` debug build type suffix and a `1.2.3` tag, that produces `1.2.3-DEBUG-my-branch`.

The suffixes are written into the inferred version name file, so they show up in the `Using versionName ...` log and in anything reading that file. When the version name isn't inferred they are applied to the DSL's version name instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)